### PR TITLE
Bug fix: environment variables in `docker-compose.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Before running the app, please install Docker first
 
 ### Backend
 
+- Create a `server/src/.env` (in `server/src`, not in the project home dir) file and set all required variables
+    ```bash
+    cp server/src/.env.template server/src/.env
+    ```
 - Start the databases
     ```bash
     $ docker-compose up -d redis postgres
@@ -58,10 +62,6 @@ Before running the app, please install Docker first
     $ cd server/src
     ```
   
-- Create a .env file and set all required variables
-    ```bash
-    cp .env.template .env
-    ```
 - Replace the OpenAI API key with your own key in the .env file
   
 - Start the backend service locally

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Before running the app, please install Docker first
     ```bash
     cp server/src/.env.template server/src/.env
     ```
+- Replace the OpenAI API key with your own key in the .env file
+  
 - Start the databases
     ```bash
     $ docker-compose up -d redis postgres
@@ -61,8 +63,6 @@ Before running the app, please install Docker first
     ```bash
     $ cd server/src
     ```
-  
-- Replace the OpenAI API key with your own key in the .env file
   
 - Start the backend service locally
     ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,19 +17,21 @@ services:
     volumes:
       - ./server/src:/app/src
       - ./chat-ui/build:/app/frontend
+    env_file:
+      - server/src/.env
     environment:
       REDIS_DB: 0
-      SERVER_HOST: "0.0.0.0"
-      REDIS_HOST: ${REDIS_HOST:-redis}
-      REDIS_PORT: ${REDIS_PORT:-6379}
-      REDIS_PASSWORD: ${REDIS_PASSWORD}
-      OPENAI_API_KEY_GPT4: ${OPENAI_API_KEY_GPT4}
-      OPENAI_API_KEY_GPT3: ${OPENAI_API_KEY_GPT3}
-      PGSQL_HOST: ${PGSQL_HOST:-postgres}
-      PGSQL_PORT: ${PGSQL_PORT:-5432}
-      PGSQL_PASS: ${PGSQL_PASS:-postgres}
-      PGSQL_USER: ${PGSQL_USER:-chatux}
-      PGSQL_DB: ${PGSQL_DB:-postgres}
+#      SERVER_HOST: "0.0.0.0"
+#      REDIS_HOST: ${REDIS_HOST:-redis}
+#      REDIS_PORT: ${REDIS_PORT:-6379}
+#      REDIS_PASSWORD: ${REDIS_PASSWORD}
+#      OPENAI_API_KEY_GPT4: ${OPENAI_API_KEY_GPT4}
+#      OPENAI_API_KEY_GPT3: ${OPENAI_API_KEY_GPT3}
+#      PGSQL_HOST: ${PGSQL_HOST:-postgres}
+#      PGSQL_PORT: ${PGSQL_PORT:-5432}
+#      PGSQL_PASS: ${PGSQL_PASS:-postgres}
+#      PGSQL_USER: ${PGSQL_USER:-chatux}
+#      PGSQL_DB: ${PGSQL_DB:-postgres}
     ports:
       - "8880:8880"
     working_dir: /app/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,21 +17,6 @@ services:
     volumes:
       - ./server/src:/app/src
       - ./chat-ui/build:/app/frontend
-    env_file:
-      - server/src/.env
-    environment:
-      REDIS_DB: 0
-#      SERVER_HOST: "0.0.0.0"
-#      REDIS_HOST: ${REDIS_HOST:-redis}
-#      REDIS_PORT: ${REDIS_PORT:-6379}
-#      REDIS_PASSWORD: ${REDIS_PASSWORD}
-#      OPENAI_API_KEY_GPT4: ${OPENAI_API_KEY_GPT4}
-#      OPENAI_API_KEY_GPT3: ${OPENAI_API_KEY_GPT3}
-#      PGSQL_HOST: ${PGSQL_HOST:-postgres}
-#      PGSQL_PORT: ${PGSQL_PORT:-5432}
-#      PGSQL_PASS: ${PGSQL_PASS:-postgres}
-#      PGSQL_USER: ${PGSQL_USER:-chatux}
-#      PGSQL_DB: ${PGSQL_DB:-postgres}
     ports:
       - "8880:8880"
     working_dir: /app/src


### PR DESCRIPTION
`docker-compose up` was producing the following error messages:
```
WARNING: The REDIS_PASSWORD variable is not set. Defaulting to a blank string.
WARNING: The OPENAI_API_KEY_GPT4 variable is not set. Defaulting to a blank string.
WARNING: The OPENAI_API_KEY_GPT3 variable is not set. Defaulting to a blank string.
```
Probably, they were symptoms of a more serious problem.

I updated `docker-compose.yml` and corresponding installation instructions in `README.md` to eliminate both the warnings and possible consequent problems.